### PR TITLE
feat: Provide database url in k8s config

### DIFF
--- a/server.yaml
+++ b/server.yaml
@@ -16,8 +16,19 @@ spec:
       containers:
       - name: server
         image: extheoisah/hxckr-core:main
+        imagePullPolicy: Always
         ports:
         - containerPort: 3000
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: db-secrets
+              key: db-url
+              optional: true
+        - name: DATABASE_URL
+          value: "postgresql://${user}:${password}@host.docker.internal:5432/hxckr"
+        # TODO: Set actual database URLs for both production (in db-secrets) and local development
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
We can now provide the database url to core in the k8s config.  We can either add it to the k8s secret (for prod deployments) or provide a hardcoded value for local dev.