### PR TITLE
chore: reduced number of replicas for services

### DIFF
--- a/k8s/base/git-service.yaml
+++ b/k8s/base/git-service.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: git-service
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: git-service

--- a/k8s/base/server.yaml
+++ b/k8s/base/server.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: server
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: server

--- a/k8s/base/softserve.yaml
+++ b/k8s/base/softserve.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: softserve
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: softserve

--- a/k8s/base/test-runners.yaml
+++ b/k8s/base/test-runners.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: javascript-test-runner
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: javascript-test-runner
@@ -34,7 +34,7 @@ kind: Deployment
 metadata:
   name: python-test-runner
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: python-test-runner

--- a/k8s/base/webhook-handler.yaml
+++ b/k8s/base/webhook-handler.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: webhook-handler
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: webhook-handler


### PR DESCRIPTION
# Reduce Number of Replicas for Services

## Description

This PR reduces the number of replicas for various services in our Kubernetes configuration to optimize resource usage and improve deployment efficiency in both development and production environments.

## Changes

- Modified the following files to set `replicas: 1` for all deployments:
  - `k8s/base/server.yaml`
  - `k8s/base/softserve.yaml`
  - `k8s/base/webhook-handler.yaml`
  - `k8s/base/test-runners.yaml`
  - `k8s/base/git-service.yaml`

## Rationale

By reducing the number of replicas to 1 for each service, we aim to:

1. Minimize resource consumption in development and testing environments.
2. Simplify debugging and troubleshooting processes.
3. Reduce costs associated with running multiple instances of each service.
4. Improve deployment speed and efficiency.

## Impact

This change will affect both development and production environments. While it may reduce high availability and load balancing capabilities, it will significantly decrease resource usage and simplify our deployment architecture.

## Testing

- Deployed the changes in a development environment to ensure all services start correctly with a single replica.
- Verified that the application functions as expected with the reduced number of replicas.

## Notes

- For production environments where high availability is crucial, we may need to adjust the number of replicas for specific services in the future.
- Monitoring should be implemented to ensure that single-replica services can handle the expected load.

Please review and provide feedback on these changes.