### PR TITLE
Add devbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.devbox

--- a/README.md
+++ b/README.md
@@ -15,14 +15,40 @@ This repository contains the Kubernetes configuration files for the hxckr projec
 
 Before running the configuration, ensure you have the following:
 
+> All dependencies will be provided by nix via DevBox
+
 1. A Kubernetes cluster set up and running
 2. `kubectl` installed and configured to communicate with your cluster
 3. Docker images for each component (or mock images for testing)
 4. `make` installed on your system
 
+## Setup DevBox
+
+The DevBox is a development environment that provides all the necessary tools and dependencies for the project. It uses Nix to manage the environment and ensure consistency across different systems.
+
+To set up the DevBox:
+
+```bash
+curl -fsSL https://get.jetify.com/devbox | bash
+```
+
 ## Deployment Instructions
 
 The hxckr application can be deployed in two environments: development and production. Each environment has its own configuration managed through Kustomize overlays.
+
+Before running the deployment commands ensure your devbox environment is setup and running
+
+> Initialising the devbox environment in the repo root folder
+
+```bash
+  devbox shell
+```
+
+> Start minikube within devbox before starting the deployment
+
+```bash
+  minikube start
+```
 
 ### Using the Makefile
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before running the deployment commands ensure your devbox environment is setup a
 
 We provide a Makefile to simplify common operations. Here are the available commands:
 
-- `make dev-deploy`: Deploy the application in the development environment
+- `make dev-deploy`: Deploy the application in the development environment(takes few seconds to complete)
 - `make dev-verify`: Verify the deployment in the development environment
 - `make dev-softserve`: Get the external IP of the softserve service in development
 - `make dev-clean`: Remove all deployed resources in the development environment
@@ -88,12 +88,15 @@ To deploy the application in the development environment:
 
 4. Wait for all pods to be in the "Running" state.
 
-5. To access the softserve service externally, get its LoadBalancer IP:
-   ```
-   make dev-softserve
-   ```
-
-6. Use the EXTERNAL-IP of the softserve service to access it externally.
+5. To access the server and softserve service externally,
+    ```bash
+     minikube service server -n hxckr-dev
+    ```
+    > and for softserve
+    ```bash
+     minikube service softserve -n hxckr-dev
+    ```
+6. Use the URL of the server and softserve service to access it externally.
 
 ### Production Deployment
 

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.0/.schema/devbox.schema.json",
+  "packages": ["kubectl", "minikube", "docker@latest"],
+  "shell": {
+    "init_hook": ["echo 'You are now in devbox!'"],
+    "scripts": {
+      "test": ["echo \"Error: no test specified\" && exit 1"]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,61 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "docker@latest": {
+      "last_modified": "2024-09-19T11:39:46Z",
+      "resolved": "github:NixOS/nixpkgs/268bb5090a3c6ac5e1615b38542a868b52ef8088#docker",
+      "source": "devbox-search",
+      "version": "27.2.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/djpji4gal3p4xb6zzfcmxvzyi763rs81-docker-27.2.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/djpji4gal3p4xb6zzfcmxvzyi763rs81-docker-27.2.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/2prvh6fb9b9zkh5d0iirx2df2azz9n9x-docker-27.2.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/2prvh6fb9b9zkh5d0iirx2df2azz9n9x-docker-27.2.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8yd9szyhz306m48i7rg3p3i6cl38wlsq-docker-27.2.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8yd9szyhz306m48i7rg3p3i6cl38wlsq-docker-27.2.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/r4p9kjvzj8amd4pc217gf098p8p2bgi8-docker-27.2.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/r4p9kjvzj8amd4pc217gf098p8p2bgi8-docker-27.2.0"
+        }
+      }
+    },
+    "kubectl": {
+      "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#kubectl",
+      "source": "nixpkg"
+    },
+    "minikube": {
+      "resolved": "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c#minikube",
+      "source": "nixpkg"
+    }
+  }
+}

--- a/k8s/base/webhook-handler.yaml
+++ b/k8s/base/webhook-handler.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,15 +13,23 @@ spec:
         app: webhook-handler
     spec:
       containers:
-      - name: webhook-handler
-        image: extheoisah/hxckr-webhook-handler:main
-        ports:
-        - containerPort: 3003
-        env:
-        - name: CORE_SERVICE_URL
-          value: "http://server:4925"
-        - name: PORT
-          value: "3003"
+        - name: webhook-handler
+          image: extheoisah/hxckr-webhook-handler:main
+          ports:
+            - containerPort: 3003
+          env:
+            - name: CORE_SERVICE_URL
+              value: "http://server:4925"
+            - name: PORT
+              value: "3003"
+            - name: RABBITMQ_HOST
+              value: "job-queue"
+            - name: RABBITMQ_PORT
+              value: "5672"
+            - name: RABBITMQ_USERNAME
+              value: "guest"
+            - name: RABBITMQ_PASSWORD
+              value: "guest"
 ---
 apiVersion: v1
 kind: Service
@@ -32,4 +39,4 @@ spec:
   selector:
     app: webhook-handler
   ports:
-  - port: 3003
+    - port: 3003


### PR DESCRIPTION
This PR adds DevBox as environment runner for running Kubernetes locally via minikube. 

It provides an isolated environment to run all the service at once for integrated development.