### PR TITLE
feat: exposed rabbit mq outside cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,3 +225,40 @@ For production:
 ```
 kubectl delete -f . -n hxckr-prod
 ```
+
+### Connecting to RabbitMQ in Local Development
+
+To connect to RabbitMQ from a service running outside the cluster in your local development environment, follow these steps:
+
+1. Ensure the job queue service is running:
+   ```
+   make dev-start-job-queue
+   ```
+
+2. Get the NodePort for the RabbitMQ service:
+   ```
+   kubectl get service job-queue -n hxckr-dev
+   ```
+   Look for the port mapping that looks like `5672:30672/TCP`. In this case, 30672 is the NodePort.
+
+3. Get the IP address of your Minikube cluster:
+   ```
+   minikube ip
+   ```
+
+4. Construct the RabbitMQ connection URL using the following format:
+   ```
+   amqp://dev_user:dev_password@<minikube-ip>:30672
+   ```
+   Replace `<minikube-ip>` with the IP address you got in step 3.
+
+   For example, if the Minikube IP is 192.168.49.2, your connection URL would be:
+   ```
+   amqp://dev_user:dev_password@192.168.49.2:30672
+   ```
+
+5. Use this connection URL in your external service to connect to RabbitMQ.
+
+Note: The username `dev_user` and password `dev_password` are set in the development overlay. If you've changed these values, make sure to use the correct credentials in your connection URL.
+
+Remember that this setup is for local development only. In a production environment, you would use a more secure method to manage and distribute connection details.

--- a/k8s/base/job-queue.yaml
+++ b/k8s/base/job-queue.yaml
@@ -18,7 +18,11 @@ spec:
         image: rabbitmq:3-management
         ports:
         - containerPort: 5672
-        - containerPort: 15672
+        env:
+        - name: RABBITMQ_DEFAULT_USER
+          value: "placeholder_user"
+        - name: RABBITMQ_DEFAULT_PASS
+          value: "placeholder_pass"
         volumeMounts:
         - name: config
           mountPath: /etc/rabbitmq/rabbitmq.conf
@@ -50,8 +54,9 @@ metadata:
 spec:
   selector:
     app: job-queue
+  type: NodePort
   ports:
   - port: 5672
+    targetPort: 5672
+    nodePort: 30672
     name: amqp
-  - port: 15672
-    name: management

--- a/k8s/overlays/development/job-queue.yaml
+++ b/k8s/overlays/development/job-queue.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: job-queue
+spec:
+  template:
+    spec:
+      containers:
+      - name: job-queue
+        env:
+        - name: RABBITMQ_DEFAULT_USER
+          value: "dev_user"
+        - name: RABBITMQ_DEFAULT_PASS
+          value: "dev_password"

--- a/k8s/overlays/development/kustomization.yaml
+++ b/k8s/overlays/development/kustomization.yaml
@@ -9,6 +9,7 @@ patches:
   - path: server-patch.yaml
   - path: server-service-patch.yaml
   - path: softserve-patch.yaml
+  - path: job-queue.yaml
 configMapGenerator:
   - name: rabbitmq-definitions
     files:

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - namespace.yaml
   - ingress.yaml
+  - job-queue.yaml
 configMapGenerator:
   - name: rabbitmq-definitions
     files:


### PR DESCRIPTION
# Expose RabbitMQ Service Outside the Cluster

## Summary
This PR modifies our RabbitMQ configuration to make it accessible from outside the Kubernetes cluster while maintaining security and flexibility across different environments.

## Changes
- Exposed RabbitMQ AMQP port (5672) using NodePort service
- Removed management port exposure for security
- Added placeholder credentials in base configuration
- Created separate overlays for development and production environments

## Details

### Base Configuration (`k8s/base/job-queue.yaml`)
- Added placeholder environment variables for RabbitMQ credentials
- Modified the Service to use NodePort, exposing port 30672 externally
- Removed the management port (15672) exposure

### Development Overlay (`k8s/overlays/development/job-queue.yaml`)
- Created a new file to override RabbitMQ credentials for development
- Set development-specific username and password

### Kustomization Updates
- Added `job-queue.yaml` to both development and production overlays

## Testing
To test these changes:
1. Apply the development overlay: `kubectl apply -k k8s/overlays/development`
2. Verify the RabbitMQ pod is running: `kubectl get pods -n hxckr-dev`
3. Check the service: `kubectl get services -n hxckr-dev`
4. Test connection to RabbitMQ using the NodePort (30672) and development credentials

Please review and test these changes in a non-production environment before merging.