### PR TITLE
chore: fixed rabbitmq dev overlay in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ dev-start-webhook-handler: dev-create-namespace
 
 dev-start-job-queue: dev-create-namespace
 	$(KUBECTL) create configmap rabbitmq-definitions --from-file=k8s/overlays/development/definitions.json -n $(DEV_NAMESPACE) --dry-run=client -o yaml | $(KUBECTL) apply -f -
-	$(KUBECTL) apply -f k8s/base/job-queue.yaml -n $(DEV_NAMESPACE)
+	$(KUBECTL) apply -k k8s/overlays/development --prune -l app=job-queue
 
 dev-start-test-runners: dev-create-namespace
 	$(KUBECTL) apply -k k8s/overlays/development --prune -l app=test-runners


### PR DESCRIPTION
## Ensure RabbitMQ development credentials are applied correctly

This PR fixes an issue where the development overlay for RabbitMQ credentials was not being applied when starting the job queue service. The `dev-start-job-queue` Makefile task has been updated to use the `-k` flag with `kubectl apply`, ensuring that the Kustomize overlay for the development environment is properly applied.

### Changes:
- Modified `dev-start-job-queue` task in Makefile to use `kubectl apply -k`
- Ensures development-specific RabbitMQ credentials are used in dev environment